### PR TITLE
add feature: .spotenv.json config support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,30 @@
 * Avoids writing secrets or sensitive defaults to `.env.example` (heuristic: keys containing `SECRET`, `TOKEN`, `KEY`, `PWD`, `PASSWORD`, `PRIVATE` are treated as sensitive).
 * Watch mode — auto-regenerate `.env.example` on file changes.
 * Merge mode — preserve keys in an existing `.env.example` while adding newly detected keys.
+* You can customize a `.spotenv.json` file - the main configuration file of spotenv - to enable you to use spotenv without the cli flags. 
 
+### Example Usage with a Configuration File
+1. Create a .spotenv.json file in the root of your project.
+2. Manually customize the individual flag options - `dir`, `out`, `watch`, `merge` and `ignore` - where `dir` refers to the target project directory to scan using both relative and absolute paths, `out` refers to the location of your `.env`, `.env.example`, `.env.local` file, specified to the directory of choice, while `watch` `merge` and `ignore` set the flags to watch, merge and list the directories to ignore scanning for environment variables respectively.
+In action, your configuration file should look like this: 
+`{
+  "dir": "/home/ubuntu/projects/project1",
+  "out": ".env.example",
+  "watch": false,
+  "merge": false,
+  "ignore": [
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/.next/**",
+    "**/.turbo/**",
+    "**/.vercel/**",
+    "**/out/**"
+  ]
+}`
+
+**NOTE**: When you reference the environment file as shown above, it creates a new one in the current project root directory.
+* With a properly configured file set up, you can run sponenv without cli options for the options specifically entered.
 ---
 
 ## When spotenv is useful (scenarios)

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,112 @@
+// configuration file functions
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { DEFAULT_IGNORE } from './constants';
+import type { SpotenvConfig } from './types';
+
+// default configuration
+const defaultConfig: SpotenvConfig = {
+	dir: process.cwd(),
+	out: '.env.example',
+	watch: false,
+	merge: false,
+	ignore: DEFAULT_IGNORE,
+};
+
+// function to find the nearest project root by looking for package.json
+function findProjectRoot(startDir: string): string | null {
+	let currentDir = resolve(startDir);
+	const markerFile = 'package.json';
+
+	while (currentDir !== dirname(currentDir)) {
+		const markerPath = join(currentDir, markerFile);
+		if (existsSync(markerPath)) {
+			return currentDir;
+		}
+		currentDir = dirname(currentDir);
+	}
+
+	return null;
+}
+
+// function to find the config file
+function findConfigFile(startDir: string = process.cwd()): string | undefined {
+	const root = findProjectRoot(startDir) ?? resolve(startDir);
+	let dir = resolve(startDir);
+
+	while (true) {
+		const path = join(dir, '.spotenv.json');
+		if (existsSync(path)) return path;
+		if (dir === root || dir === dirname(dir)) break;
+		dir = dirname(dir);
+	}
+
+	// check root
+	const possibleRootPath = join(root, '.spotenv.json');
+	if (existsSync(possibleRootPath)) return possibleRootPath;
+
+	return undefined;
+}
+
+/*function createConfigFile(startDir: string = process.cwd()): string | undefined {
+    // default configuration
+    const defaultConfig: SpotenvConfig = {
+        dir: findProjectRoot(process.cwd()),
+        out: '.env.example',
+        watch: false,
+        merge: false,
+        ignore: DEFAULT_IGNORE,
+    }
+    let configDir = findProjectRoot(startDir);
+    if (configDir === null) {
+        console.error('No project root found. Please run in a valid project directory.');
+        process.exit(1);
+    }
+    let spotenvConfigFile = join(configDir, '.spotenv.json');
+
+    if (existsSync(spotenvConfigFile)) {
+        console.warn(`${spotenvConfigFile} already exists. Skipping creation.`);
+        return;
+    }
+
+    const configContent = JSON.stringify(defaultConfig, null, 2);
+    try {
+        writeFileSync(spotenvConfigFile, configContent);
+        console.log(`Created ${spotenvConfigFile}`);
+        return spotenvConfigFile
+    } catch (error) {
+        console.error(`Error creating ${spotenvConfigFile}:`, error);
+        process.exit(1);
+    }
+}*/
+
+// function to load the configuration file if it exists
+export function loadSpotenvConfig(startDir: string = process.cwd()): {
+	path?: string;
+	config?: SpotenvConfig;
+} {
+	const path = findConfigFile(startDir);
+	if (!path) return { path: undefined, config: defaultConfig };
+
+	try {
+		const data = readFileSync(path, 'utf-8');
+		const parsedData = JSON.parse(data) as SpotenvConfig;
+		return { path, config: { ...defaultConfig, ...parsedData } };
+	} catch (error) {
+		console.error(`Error reading configuration file ${path}:`, error);
+		return { path, config: defaultConfig };
+	}
+}
+
+// merge CLI options with config but CLI takes precedence
+export function mergeConfigWithCliOptions(
+	config: SpotenvConfig | undefined,
+	cliOptions: Record<string, any>,
+): SpotenvConfig {
+	const currentConfig = config ?? defaultConfig;
+	return {
+		...currentConfig,
+		...cliOptions,
+		ignore: cliOptions.ignore ?? currentConfig.ignore ?? DEFAULT_IGNORE,
+	};
+}

--- a/src/utils/program.ts
+++ b/src/utils/program.ts
@@ -1,9 +1,25 @@
 import { Command } from 'commander';
 import { version } from '../../package.json';
+import { loadSpotenvConfig, mergeConfigWithCliOptions } from './config';
 import { DEFAULT_IGNORE } from './constants';
 
 export function initialProgram(): Command {
 	const program = new Command();
+
+	// load the configuration file
+	const { path, config: loadedConfig } = loadSpotenvConfig();
+	const config = loadedConfig ?? {
+		dir: process.cwd(),
+		out: '.env.example',
+		watch: false,
+		merge: false,
+		ignore: DEFAULT_IGNORE,
+	};
+
+	if (path) {
+		console.log(`Using configuration file: ${path}`);
+	}
+
 	program
 		.name('spotenv')
 		.description(
@@ -11,20 +27,39 @@ export function initialProgram(): Command {
 		)
 		.version(version)
 		.showHelpAfterError()
-		.requiredOption('-d, --dir <dir>', 'project directory to scan')
-		.option('-o, --out <file>', 'path for output file', '.env.example')
-		.option('-w, --watch', 'watch files and auto-regenerate', false)
+		.requiredOption(
+			'-d, --dir <dir>',
+			'project directory to scan',
+			config.dir ?? process.cwd(),
+		)
+		.option(
+			'-o, --out <file>',
+			'path for output file',
+			config.out ?? '.env.example',
+		)
+		.option(
+			'-w, --watch',
+			'watch files and auto-regenerate',
+			config.watch ?? false,
+		)
 		.option(
 			'-m, --merge',
 			'merge with existing .env.example (keep existing keys)',
-			false,
+			config.merge ?? false,
 		)
 		.option(
 			'--ignore <patterns...>',
 			'glob ignore patterns',
-			DEFAULT_IGNORE,
+			config.ignore ?? DEFAULT_IGNORE,
 		)
 		.parse(process.argv);
+
+	// Merge cli options with config file
+	const cliOptions = program.opts();
+	const finalConfig = mergeConfigWithCliOptions(config, cliOptions);
+
+	// update program options with finalConfig
+	Object.assign(program.opts(), finalConfig);
 
 	return program;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,9 @@
+// types for the configuration file
+
+export interface SpotenvConfig {
+	dir?: string | null;
+	out?: string;
+	watch?: boolean;
+	merge?: boolean;
+	ignore?: string[];
+}


### PR DESCRIPTION
## 🚀 Pull Request Summary

**What does this PR do?**
It completes and satisfies a feature request to add `.spotenv.json` configuration to enable users to use the application without having to use CLI options with the presence of said configuration file.

---

## 📋 Related Issues

Fixes: #1 (Adds `.spotenv.json` config support)
Related: #1 (Adds `.spotenv.json` config support)

---

## 🔍 Changes in This PR

- [x] Feature added
- [ ] Bug fixed
- [ ] Refactoring
- [x] Documentation updated
- [ ] Tests added/updated
- [ ] Other (please describe):

---

## 🧪 How to Test

**Steps to test this PR:**
1. add a  `.spotenv.json` configuration file with the required options - dir, out, watch, merge, and ignore.
2. Run the application without the CLI options.


---

## ✅ Checklist

- [x] I have tested my code thoroughly.
- [x] I have reviewed my own code and refactored where necessary.
- [x] I have added relevant comments and documentation.
- [x] My changes follow the project's coding style.
- [x] I have linked the related issues above.
- [ ] I have added or updated tests where applicable.

---

## 💬 Additional Notes

It's been fun working on this feature even if it took my entire day :-).
