### PR TITLE
feat(cli): add multiple format output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "spotenv",
-	"version": "0.9.3",
+	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "spotenv",
-			"version": "0.9.3",
+			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.28.0",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,8 +9,3 @@ export const DEFAULT_IGNORE = [
 	'**/.vercel/**',
 	'**/out/**',
 ];
-
-export const DEFAULT_TARGET_ENV_EXAMPLE_FILE = join(
-	process.cwd(),
-	'.env.example',
-);

--- a/src/utils/extract.ts
+++ b/src/utils/extract.ts
@@ -11,7 +11,7 @@ import {
 	tryExtractDefaultFromParent,
 } from './helpers';
 
-type KeyMeta = {
+export type KeyMeta = {
 	key: string;
 	files: Set<string>;
 	isDynamic?: boolean;

--- a/src/utils/program.ts
+++ b/src/utils/program.ts
@@ -7,12 +7,12 @@ export function initialProgram(): Command {
 	program
 		.name('spotenv')
 		.description(
-			'Scan project for environment variable usage and generate .env.example',
+			'Scan project for environment variable usage and generate .env.sample-filename',
 		)
 		.version(version)
 		.showHelpAfterError()
 		.requiredOption('-d, --dir <dir>', 'project directory to scan')
-		.option('-o, --out <file>', 'path for output file', '.env.example')
+		.option('-o, --out <file>', 'path for output file', 'sample-filename')
 		.option('-w, --watch', 'watch files and auto-regenerate', false)
 		.option(
 			'-m, --merge',
@@ -23,6 +23,11 @@ export function initialProgram(): Command {
 			'--ignore <patterns...>',
 			'glob ignore patterns',
 			DEFAULT_IGNORE,
+		)
+		.option(
+			'-f, --format <extension>',
+			'output format for environment variables (env, json, yml)',
+			'env',
 		)
 		.parse(process.argv);
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,1 @@
+export type Format = 'json' | 'env' | 'yml';


### PR DESCRIPTION
## 🚀 Pull Request Summary

**What does this PR do?**
<!-- A short summary of the changes introduced by this PR -->

This PR introduces multiple output format support and custom filename handling to spotenv.  
Users can now generate environment variable files in JSON, YAML, and ENV formats with custom filenames and automatic path/extension handling.

---

## 📋 Related Issues

Fixes: #3
Related: #3

---

## 🔍 Changes in This PR

- [x] Feature added
- [ ] Bug fixed
- [x] Refactoring
- [x] Documentation updated
- [ ] Tests added/updated
- [ ] Other (please describe):

---

## 🧪 How to Test

**Steps to test this PR:**

1. Install the updated package: npm install -g spotenv
2. Test basic usage: spotenv -d . -o example
3. Test JSON format: spotenv -d . -f json -o env-config
4. Test YAML format: spotenv -d . -f yml -o environment
5. Test custom paths: spotenv -d . -f json -o ./config/env-vars

---

## ✅ Checklist

- [x] I have tested my code thoroughly.
- [x] I have reviewed my own code and refactored where necessary.
- [x] I have added relevant comments and documentation.
- [x] My changes follow the project's coding style.
- [x] I have linked the related issues above.
- [ ] I have added or updated tests where applicable.

---

## 💬 Additional Notes

<!-- Anything else reviewers should know -->

* The default output filename has been changed from .env.example to sample-filename to better reflect the customizable nature of the tool
* All render functions have been refactored to eliminate code duplication and improve maintainability
* The CLI now supports three output formats: env (default), json, and yml
* Comprehensive documentation has been updated with examples for all new features
