### PR TITLE
feat(cli): add types output (#8)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,9 @@ spotenv -d . -f yml -o environment
 # Watch and auto-regenerate (COMMING SOON!)
 spotenv -w
 
+# ➕ Generate TypeScript types (env.d.ts)
+spotenv -d . -t
+
 ```
 
 ### CLI options
@@ -139,6 +142,7 @@ spotenv -w
 * `-m, --merge` — merge results with an existing `.env.sample-filename` (keep existing keys)
 * `--ignore <patterns...>` — additional glob ignore patterns
 * `-f, --format <extension>` — output format for environment variables (env, json, yml) (default: `env`)
+* `-t, --types` — generate TypeScript definition file (env.d.ts)
 Examples:
 
 ```bash
@@ -153,6 +157,9 @@ spotenv -d ./my-app -f yml -o config
 
 # watch updates into existing example (COMMING SOON!)
 spotenv -w
+
+# Generate TypeScript types (env.d.ts)
+spotenv -d ./my-app -t
 ```
 
 ---

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import ora from 'ora';
 import { DEFAULT_IGNORE } from './utils/constants';
 import { inferOutputTarget } from './utils/helpers';
 import { initialProgram } from './utils/program';
-import { renderFile, writeFile } from './utils/render';
+import { renderFile, writeDeifinitionFile, writeFile } from './utils/render';
 import { scanProject } from './utils/scan';
 import type { Format } from './utils/types';
 
@@ -65,6 +65,13 @@ async function main() {
 					} env keys`,
 				)
 				.stop();
+			if (options.types) {
+				writeDeifinitionFile(envMap);
+				console.log(
+					chalk.green(`Type definition has generated env.d.ts`),
+				);
+			}
+
 			const content = renderFile(envMap, targetFormat as Format);
 			await writeFile(finalPath as string, content, requestToMerge);
 			if (outputFileExists && requestToMerge) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -12,6 +12,7 @@ const defaultConfig: SpotenvConfig = {
 	merge: false,
 	ignore: DEFAULT_IGNORE,
 	format: 'env',
+	types: false,
 };
 
 // function to find the nearest project root by looking for package.json

--- a/src/utils/program.ts
+++ b/src/utils/program.ts
@@ -14,6 +14,8 @@ export function initialProgram(): Command {
 		watch: false,
 		merge: false,
 		ignore: DEFAULT_IGNORE,
+		format: 'env',
+		types: false,
 	};
 
 	if (path) {
@@ -56,6 +58,11 @@ export function initialProgram(): Command {
 			'-f, --format <extension>',
 			'output format for environment variables (env, json, yml)',
 			config?.format,
+		)
+		.option(
+			'-t, --types',
+			'generate TypeScript definition file (env.d.ts) from .env.example',
+			config?.types,
 		)
 		.parse(process.argv);
 

--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -170,3 +170,15 @@ export async function writeFile(
 		outputFile(resolve(outPath), content);
 	}
 }
+
+export function writeDeifinitionFile(envKeyMap: EnvKeyMap) {
+	const typeDefinition =
+		`declare namespace NodeJS {\n` +
+		`  interface ProcessEnv {\n` +
+		Array.from(envKeyMap.keys())
+			.map((k) => `    ${k}: string;`)
+			.join('\n') +
+		`\n  }\n}`;
+
+	outputFile(resolve('env.d.ts'), typeDefinition);
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -8,4 +8,5 @@ export interface SpotenvConfig {
 	merge?: boolean;
 	ignore?: string[];
 	format?: Format;
+	types?: boolean;
 }


### PR DESCRIPTION
## 🚀 Pull Request Summary

**What does this PR do?**
Adds a new --types / -t CLI option to generate a TypeScript definition file (env.d.ts).

---

## 📋 Related Issues

Fixes: #8

---

## 🔍 Changes in This PR

- [x] Feature added: --types / -t CLI option for TypeScript type generation
- [x] CLI help/description updated with new option
- [x] Documentation updated

---

## 🧪 How to Test

**Steps to test this PR:**
1. Run `spotenv --types` to generate env.d.ts in the project root.
3. Verify the generated file matches the environment keys.

---

## ✅ Checklist

- [x] I have tested my code thoroughly.
- [x] I have reviewed my own code and refactored where necessary.
- [x] I have added relevant comments and documentation.
- [x] My changes follow the project's coding style.
- [x] I have linked the related issues above.
- [ ] I have added or updated tests where applicable.

---

## 💬 Additional Notes

No breaking changes.  